### PR TITLE
Add preferred language, unit, and time format

### DIFF
--- a/src/components/SignUpForm.astro
+++ b/src/components/SignUpForm.astro
@@ -1,5 +1,6 @@
 ---
 import ContactInformation from "./contact-info/ContactInformation.astro";
+import UserPreferences from "./user-preferences/UserPreferences.astro";
 import InstantAlerts from "./notifications/instant/InstantAlerts.astro";
 import DailyNotifications from "./notifications/daily/DailyNotifications.astro";
 ---
@@ -11,6 +12,7 @@ import DailyNotifications from "./notifications/daily/DailyNotifications.astro";
   <form class="space-y-8">
     <div class="space-y-8">
       <ContactInformation />
+      <UserPreferences />
 
       <section>
         <h2 class="text-lg font-semibold text-slate-800 mb-6">Notification Preferences</h2>

--- a/src/components/user-preferences/UserPreferences.astro
+++ b/src/components/user-preferences/UserPreferences.astro
@@ -30,9 +30,12 @@ const units: Unit[] = [
             <select 
                 id="language" 
                 name="language" 
+                aria-label="Select your preferred language"
+                aria-required="true"
                 class="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
             >
+                <option value="" disabled selected>Select a language...</option>
                 {languages.map(lang => (
                     <option value={lang.code}>
                         {lang.name}
@@ -49,9 +52,12 @@ const units: Unit[] = [
             <select 
                 id="unit" 
                 name="unit" 
+                aria-label="Select your preferred measurement unit"
+                aria-required="true"
                 class="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
             >
+                <option value="" disabled selected>Select measurement units...</option>
                 {units.map(unit => (
                     <option value={unit.code}>
                         {unit.name}
@@ -59,6 +65,7 @@ const units: Unit[] = [
                 ))}
             </select>
         </div>
+
         <!-- 24h vs 12h time format -->
         <div>
             <label for="timeFormat" class="block text-sm font-medium text-slate-700 mb-1">
@@ -67,9 +74,12 @@ const units: Unit[] = [
             <select 
                 id="timeFormat" 
                 name="timeFormat" 
+                aria-label="Select your preferred time format"
+                aria-required="true"
                 class="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
             >
+                <option value="" disabled selected>Select time format...</option>
                 <option value="24h">24h (eg. 23:00)</option>
                 <option value="12h">12h (eg. 11:00 PM)</option>
             </select>

--- a/src/components/user-preferences/UserPreferences.astro
+++ b/src/components/user-preferences/UserPreferences.astro
@@ -16,6 +16,11 @@ const units: Unit[] = [
 	{ code: "metric", name: "Metric (°C, meters, liters)" },
 	{ code: "imperial", name: "Imperial (°F, miles, gallons)" },
 ];
+
+const timeFormats: Option[] = [
+	{ code: "24h", name: "24h (eg. 23:00)" },
+	{ code: "12h", name: "12h (eg. 11:00 PM)" },
+];
 ---
 
 <section class="user-preferences">
@@ -78,9 +83,11 @@ const units: Unit[] = [
                 class="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
             >
-                <option value="" disabled selected>Select time format...</option>
-                <option value="24h">24h (eg. 23:00)</option>
-                <option value="12h">12h (eg. 11:00 PM)</option>
+                {timeFormats.map(timeFormat => (
+                    <option value={timeFormat.code}>
+                        {timeFormat.name}
+                    </option>
+                ))}
             </select>
         </div>
     </div>

--- a/src/components/user-preferences/UserPreferences.astro
+++ b/src/components/user-preferences/UserPreferences.astro
@@ -59,6 +59,21 @@ const units: Unit[] = [
                 ))}
             </select>
         </div>
+        <!-- 24h vs 12h time format -->
+        <div>
+            <label for="timeFormat" class="block text-sm font-medium text-slate-700 mb-1">
+                Time Format
+            </label>
+            <select 
+                id="timeFormat" 
+                name="timeFormat" 
+                class="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                required
+            >
+                <option value="24h">24h (eg. 23:00)</option>
+                <option value="12h">12h (eg. 11:00 PM)</option>
+            </select>
+        </div>
     </div>
 </section>
 
@@ -67,22 +82,37 @@ const units: Unit[] = [
     function setInitialPreferences() {
         const languageSelect = document.getElementById('language') as HTMLSelectElement;
         const unitSelect = document.getElementById('unit') as HTMLSelectElement;
+        const timeFormatSelect = document.getElementById('timeFormat') as HTMLSelectElement;
+        if (languageSelect && unitSelect && timeFormatSelect) {
+            try {
+                // Get browser's language and region, default to en-US if not available
+                const [lang, region] = (navigator.language || 'en-US').split('-');
+                
+                // Set language if it's available in our options
+                if (lang && ['en'].includes(lang.toLowerCase())) {
+                    languageSelect.value = lang.toLowerCase();
+                } else {
+                    languageSelect.value = 'en';
+                }
+                
+                // Set unit based on region, default to imperial if region is missing or error occurs
+                if (region && !['US', 'MM', 'LR'].includes(region.toUpperCase())) {
+                    unitSelect.value = 'metric';
+                } else {
+                    unitSelect.value = 'imperial';
+                }
 
-        if (languageSelect && unitSelect) {
-            // Get browser's language and region
-            const [lang, region] = navigator.language.split('-');
-            
-            // Set language if it's available in our options
-            if (lang && ['en'].includes(lang.toLowerCase())) {
-                languageSelect.value = lang.toLowerCase();
-            }
-            
-            // Set unit based on region
-            if (region && ['US', 'MM', 'LR'].includes(region.toUpperCase())) {
+                // Detect time format preference using a sample date
+                const sampleDate = new Date();
+                const timeString = sampleDate.toLocaleTimeString();
+                // If AM/PM is present in the time string, use 12h format
+                timeFormatSelect.value = timeString.match(/AM|PM/i) ? '12h' : '24h';
+
+            } catch (error) {
+                // If anything goes wrong, default to en/imperial/24h
+                languageSelect.value = 'en';
                 unitSelect.value = 'imperial';
-            }
-            else {
-                unitSelect.value = 'metric';
+                timeFormatSelect.value = '24h';
             }
         }
     }

--- a/src/components/user-preferences/UserPreferences.astro
+++ b/src/components/user-preferences/UserPreferences.astro
@@ -1,13 +1,12 @@
 ---
-interface Language {
+
+interface Option {
 	code: string;
 	name: string;
 }
 
-interface Unit {
-	code: string;
-	name: string;
-}
+type Language = Option;
+type Unit = Option;
 
 // Define available languages (English only for now)
 const languages: Language[] = [{ code: "en", name: "English" }];
@@ -93,6 +92,7 @@ const units: Unit[] = [
         const languageSelect = document.getElementById('language') as HTMLSelectElement;
         const unitSelect = document.getElementById('unit') as HTMLSelectElement;
         const timeFormatSelect = document.getElementById('timeFormat') as HTMLSelectElement;
+        const imperialCountries = ['US', 'MM', 'LR'];
         if (languageSelect && unitSelect && timeFormatSelect) {
             try {
                 // Get browser's language and region, default to en-US if not available
@@ -106,17 +106,19 @@ const units: Unit[] = [
                 }
                 
                 // Set unit based on region, default to imperial if region is missing or error occurs
-                if (region && !['US', 'MM', 'LR'].includes(region.toUpperCase())) {
+                if (region && !imperialCountries.includes(region.toUpperCase())) {
                     unitSelect.value = 'metric';
                 } else {
                     unitSelect.value = 'imperial';
                 }
 
-                // Detect time format preference using a sample date
-                const sampleDate = new Date();
-                const timeString = sampleDate.toLocaleTimeString();
-                // If AM/PM is present in the time string, use 12h format
-                timeFormatSelect.value = timeString.match(/AM|PM/i) ? '12h' : '24h';
+                // Detect time format preference by checking if the locale uses 12h or 24h time format
+                const formatter = new Intl.DateTimeFormat(navigator.language, { 
+                    hour: 'numeric',
+                    hour12: undefined 
+                } as const);
+                const is12Hour = formatter.resolvedOptions().hour12 ?? true;
+                timeFormatSelect.value = is12Hour ? '12h' : '24h';
 
             } catch (error) {
                 // If anything goes wrong, default to en/imperial/24h
@@ -127,6 +129,6 @@ const units: Unit[] = [
         }
     }
 
-    // Run on page load
-    document.addEventListener('DOMContentLoaded', setInitialPreferences);
+    // Run initialization immediately
+    setInitialPreferences();
 </script> 

--- a/src/components/user-preferences/UserPreferences.astro
+++ b/src/components/user-preferences/UserPreferences.astro
@@ -1,0 +1,92 @@
+---
+interface Language {
+	code: string;
+	name: string;
+}
+
+interface Unit {
+	code: string;
+	name: string;
+}
+
+// Define available languages (English only for now)
+const languages: Language[] = [{ code: "en", name: "English" }];
+
+// Define available units
+const units: Unit[] = [
+	{ code: "metric", name: "Metric (°C, meters, liters)" },
+	{ code: "imperial", name: "Imperial (°F, miles, gallons)" },
+];
+---
+
+<section class="user-preferences">
+    <h2 class="text-lg font-semibold text-slate-800 mb-6">Preferences</h2>
+    <div class="flex flex-col gap-6">
+        <!-- Language Selection -->
+        <div>
+            <label for="language" class="block text-sm font-medium text-slate-700 mb-1">
+                Language
+            </label>
+            <select 
+                id="language" 
+                name="language" 
+                class="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                required
+            >
+                {languages.map(lang => (
+                    <option value={lang.code}>
+                        {lang.name}
+                    </option>
+                ))}
+            </select>
+        </div>
+
+        <!-- Unit Selection -->
+        <div>
+            <label for="unit" class="block text-sm font-medium text-slate-700 mb-1">
+                Measurement Units
+            </label>
+            <select 
+                id="unit" 
+                name="unit" 
+                class="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                required
+            >
+                {units.map(unit => (
+                    <option value={unit.code}>
+                        {unit.name}
+                    </option>
+                ))}
+            </select>
+        </div>
+    </div>
+</section>
+
+<script>
+    // Set initial preferences based on browser settings
+    function setInitialPreferences() {
+        const languageSelect = document.getElementById('language') as HTMLSelectElement;
+        const unitSelect = document.getElementById('unit') as HTMLSelectElement;
+
+        if (languageSelect && unitSelect) {
+            // Get browser's language and region
+            const [lang, region] = navigator.language.split('-');
+            
+            // Set language if it's available in our options
+            if (lang && ['en'].includes(lang.toLowerCase())) {
+                languageSelect.value = lang.toLowerCase();
+            }
+            
+            // Set unit based on region
+            if (region && ['US', 'MM', 'LR'].includes(region.toUpperCase())) {
+                unitSelect.value = 'imperial';
+            }
+            else {
+                unitSelect.value = 'metric';
+            }
+        }
+    }
+
+    // Run on page load
+    document.addEventListener('DOMContentLoaded', setInitialPreferences);
+</script> 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new user preferences section in the sign-up process. Users can now select their language and measurement unit options, with default values automatically set based on browser settings.
	- Added dropdowns for selecting time format preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

![CleanShot 2025-02-01 at 20 27 16](https://github.com/user-attachments/assets/78a6bf19-1358-41e0-af6d-4ddce30b6cc3)
